### PR TITLE
WSL fixes

### DIFF
--- a/MS2Proto2/Makefile
+++ b/MS2Proto2/Makefile
@@ -2,7 +2,7 @@
 # Build system for the core library and tests/benchmarks
 
 CC = gcc
-CFLAGS = -std=c99 -Wall -Wextra -O3 -g
+CFLAGS = -std=c99 -Wall -Wextra -O3 -g -D_DEFAULT_SOURCE
 
 # Directories
 SRCDIR = src

--- a/MS2Proto2/src/assembler/main.c
+++ b/MS2Proto2/src/assembler/main.c
@@ -87,11 +87,21 @@ static bool assemble_file(FILE *file, Assembler *asm) {
         line_num++;
         
         // Remove newline
-        char *nl = strchr(line, '\n');
-        if (nl) *nl = '\0';
+        char *nl = strchr(line, '\r');
+        if (nl){
+		*nl = '\0';
+	}
+	else {
+		nl = strchr(line, '\n');
+	        if (nl) *nl = '\0';
+	}
         
         if (!process_line(asm, line)) {
-            fprintf(stderr, "Error on line %d: %s\n", line_num, line);
+            fprintf(stderr, "Error on line %d (len: %ld): %s\n", line_num, strlen(line), line);
+            for(size_t i=0;i<strlen(line);i++)
+            {
+                printf("Line[%ld] = %c [%d]\n", i, line[i], line[i]);
+            }
             success = false;
             break;
         }

--- a/MS2Proto2/src/assembler/main.c
+++ b/MS2Proto2/src/assembler/main.c
@@ -89,12 +89,12 @@ static bool assemble_file(FILE *file, Assembler *asm) {
         // Remove newline
         char *nl = strchr(line, '\r');
         if (nl){
-		*nl = '\0';
-	}
-	else {
-		nl = strchr(line, '\n');
+		    *nl = '\0';
+	    }
+	    else {
+		    nl = strchr(line, '\n');
 	        if (nl) *nl = '\0';
-	}
+	    }
         
         if (!process_line(asm, line)) {
             fprintf(stderr, "Error on line %d (len: %ld): %s\n", line_num, strlen(line), line);


### PR DESCRIPTION
I encountered two problems trying to compile and run ms2asm under Windows Subsystem for Linux.

1. ms2asm was always seg faulting at `strtok`. This is because `strdup` was not being properly exposed from string.h due to how gcc looks for it with the `-std=c99` flag.
2. ms2asm could not execute any programs with a blank line. This was because they had \r\n line endings.

I implemented the following respective solutions:

1. Define _DEFAULT_SOURCE in CFLAGS in the ms2proto makefile.
2. Added a check first for '\r' and only for '\n' if '\r' couldn't be found. This should handle both Unix and Linux new line ending conventions.

The example asm programs run now for me.