### PR TITLE
Cpp fix crlf

### DIFF
--- a/MS2Proto3/VM_DESIGN.md
+++ b/MS2Proto3/VM_DESIGN.md
@@ -25,6 +25,7 @@ Our internal opcode names include a verb/mnemonic, and a description of how the 
 | BRFALSE_rA_iBC | if R[A] is false then PC += BC (16-bit signed) |
 | BRLT_rA_rB_iC | if R[A] < R[B] then PC += C (8-bit signed) |
 | BRLT_rA_iB_iC | if R[A] < B then PC += C (8-bit signed) |
+| BRLT_iA_rB_iC | if A < R[B] then PC += C (8-bit signed) |
 | IFLT_rA_rB | if R[A] < R[B] is **false** then PC += 1 |
 | IFLT_rA_iBC | if R[A] < BC is **false** then PC += 1 |
 | IFLT_iAB_rC | if AB < R[C] is **false** then PC += 1 |

--- a/MS2Proto3/VM_DESIGN.md
+++ b/MS2Proto3/VM_DESIGN.md
@@ -18,6 +18,7 @@ Our internal opcode names include a verb/mnemonic, and a description of how the 
 | SUB_rA_rB_rC | R[A] := R[B] - R[C] |
 | MULT_rA_rB_rC | R[A] := R[B] * R[C] |
 | DIV_rA_rB_rC | R[A] := R[B] / R[C] |
+| MOD_rA_rB_rC | R[A] := R[B] % R[C] |
 | LT_rA_rB_rC | R[A] := (R[B] < R[C]) |
 | JUMP_iABC | PC += ABC (24-bit signed value) |
 | BRTRUE_rA_iBC | if R[A] is true then PC += BC (16-bit signed) |

--- a/MS2Proto3/cs/Bytecode.cs
+++ b/MS2Proto3/cs/Bytecode.cs
@@ -15,18 +15,21 @@ namespace MiniScript {
 		DIV_rA_rB_rC = 7,
 		MOD_rA_rB_rC = 8,
 		JUMP_iABC = 9,
-		IFLT_rA_rB = 10,
-		IFLT_rA_iBC = 11,
-		IFLT_iAB_rC = 12,
-		IFLE_rA_rB = 13,
-		IFLE_rA_iBC = 14,
-		IFLE_iAB_rC = 15,
-		IFEQ_rA_rB = 16,
-		IFEQ_rA_iBC = 17,
-		IFNE_rA_rB = 18,
-		IFNE_rA_iBC = 19,
-		CALLF_iA_iBC = 20,
-		RETURN = 21
+		BRLT_rA_rB_iC = 10,
+		BRLT_rA_iB_iC = 11,
+		BRLT_iA_rB_iC = 12,
+		IFLT_rA_rB = 13,
+		IFLT_rA_iBC = 14,
+		IFLT_iAB_rC = 15,
+		IFLE_rA_rB = 16,
+		IFLE_rA_iBC = 17,
+		IFLE_iAB_rC = 18,
+		IFEQ_rA_rB = 19,
+		IFEQ_rA_iBC = 20,
+		IFNE_rA_rB = 21,
+		IFNE_rA_iBC = 22,
+		CALLF_iA_iBC = 23,
+		RETURN = 24
 	}
 
 	public static class BytecodeUtil {
@@ -78,6 +81,9 @@ namespace MiniScript {
 				case Opcode.DIV_rA_rB_rC:  return "DIV_rA_rB_rC";
 				case Opcode.MOD_rA_rB_rC:  return "MOD_rA_rB_rC";
 				case Opcode.JUMP_iABC:     return "JUMP_iABC";
+				case Opcode.BRLT_rA_rB_iC: return "BRLT_rA_rB_iC";
+				case Opcode.BRLT_rA_iB_iC: return "BRLT_rA_iB_iC";
+				case Opcode.BRLT_iA_rB_iC: return "BRLT_iA_rB_iC";
 				case Opcode.IFLT_rA_rB:    return "IFLT_rA_rB";
 				case Opcode.IFLT_rA_iBC:   return "IFLT_rA_iBC";
 				case Opcode.IFLT_iAB_rC:   return "IFLT_iAB_rC";
@@ -106,6 +112,9 @@ namespace MiniScript {
 			if (s == "DIV_rA_rB_rC")  return Opcode.DIV_rA_rB_rC;
 			if (s == "MOD_rA_rB_rC")  return Opcode.MOD_rA_rB_rC;
 			if (s == "JUMP_iABC")     return Opcode.JUMP_iABC;
+			if (s == "BRLT_rA_rB_iC") return Opcode.BRLT_rA_rB_iC;
+			if (s == "BRLT_rA_iB_iC") return Opcode.BRLT_rA_iB_iC;
+			if (s == "BRLT_iA_rB_iC") return Opcode.BRLT_iA_rB_iC;
 			if (s == "IFLT_rA_rB")    return Opcode.IFLT_rA_rB;
 			if (s == "IFLT_rA_iBC")   return Opcode.IFLT_rA_iBC;
 			if (s == "IFLT_iAB_rC")   return Opcode.IFLT_iAB_rC;

--- a/MS2Proto3/cs/Disassembler.cs
+++ b/MS2Proto3/cs/Disassembler.cs
@@ -21,6 +21,9 @@ namespace MiniScript {
 				case Opcode.MOD_rA_rB_rC:  return "MOD";
 				case Opcode.SUB_rA_rB_rC:  return "SUB";
 				case Opcode.JUMP_iABC:     return "JUMP";
+				case Opcode.BRLT_rA_rB_iC:
+				case Opcode.BRLT_rA_iB_iC:
+				case Opcode.BRLT_iA_rB_iC: return "BRLT";
 				case Opcode.IFLT_rA_rB:
 				case Opcode.IFLT_rA_iBC:
 				case Opcode.IFLT_iAB_rC:   return "IFLT";
@@ -107,6 +110,27 @@ namespace MiniScript {
 				case Opcode.DIV_rA_rB_rC:
 				case Opcode.MOD_rA_rB_rC:
         			return StringUtils.Format("{0} r{1}, r{2}, r{3}",
+        				mnemonic,
+        				(Int32)BytecodeUtil.Au(instruction),
+        				(Int32)BytecodeUtil.Bu(instruction),
+        				(Int32)BytecodeUtil.Cu(instruction));
+				// rA, rB, iC
+				case Opcode.BRLT_rA_rB_iC:
+					return StringUtils.Format("{0} r{1}, r{2}, {3}",
+        				mnemonic,
+        				(Int32)BytecodeUtil.Au(instruction),
+        				(Int32)BytecodeUtil.Bu(instruction),
+        				(Int32)BytecodeUtil.Cu(instruction));
+				// rA, iB, iC
+				case Opcode.BRLT_rA_iB_iC:
+					return StringUtils.Format("{0} r{1}, {2}, {3}",
+        				mnemonic,
+        				(Int32)BytecodeUtil.Au(instruction),
+        				(Int32)BytecodeUtil.Bu(instruction),
+        				(Int32)BytecodeUtil.Cu(instruction));
+				// iA, rB, iC
+				case Opcode.BRLT_iA_rB_iC:
+					return StringUtils.Format("{0} {1}, r{2}, {3}",
         				mnemonic,
         				(Int32)BytecodeUtil.Au(instruction),
         				(Int32)BytecodeUtil.Bu(instruction),

--- a/MS2Proto3/cs/IOHelper.cs
+++ b/MS2Proto3/cs/IOHelper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 // CPP: #include <stdio.h>
 // CPP: #include <fstream>
 // CPP: #include <string>
+// CPP: #include <algorithm>
 
 public static class IOHelper {
 
@@ -56,6 +57,7 @@ public static class IOHelper {
 		
 		std::string line;
 		while (std::getline(file, line)) {
+			line.erase( std::remove(line.begin(), line.end(), '\r'), line.end() );
 			lines.Add(String(line.c_str()));
 		}
 		file.close();

--- a/MS2Proto3/cs/VM.cs
+++ b/MS2Proto3/cs/VM.cs
@@ -209,6 +209,39 @@ namespace MiniScript {
 						break;
 					}
 
+					case Opcode.BRLT_rA_rB_iC: {
+						// if R[A] < R[B] then jump offset C.
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						SByte offset = BytecodeUtil.Cs(instruction);
+						if(value_lt(stack[baseIndex + a], stack[baseIndex + b])){
+							pc += offset;
+						}
+						break;
+					}
+
+					case Opcode.BRLT_rA_iB_iC: {
+						// if R[A] < B (immediate) then jump offset C.
+						Byte a = BytecodeUtil.Au(instruction);
+						SByte b = BytecodeUtil.Bs(instruction);
+						SByte offset = BytecodeUtil.Cs(instruction);
+						if(value_lt(stack[baseIndex + a], make_int(b))){
+							pc += offset;
+						}
+						break;
+					}
+
+					case Opcode.BRLT_iA_rB_iC: {
+						// if A (immediate) < R[B] then jump offset C.
+						SByte a = BytecodeUtil.As(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						SByte offset = BytecodeUtil.Cs(instruction);
+						if(value_lt(make_int(a), stack[baseIndex + b])){
+							pc += offset;
+						}
+						break;
+					}
+
 					case Opcode.IFLT_rA_rB: {
 						// if R[A] < R[B] is false, skip next instruction
 						Byte a = BytecodeUtil.Au(instruction);

--- a/MS2Proto3/examples/branching.msa
+++ b/MS2Proto3/examples/branching.msa
@@ -1,0 +1,16 @@
+@main:
+    LOAD r0, 50
+    BRLT r0, 0, negative
+    BRLT r0, 100, positive
+    JUMP large
+    
+negative:
+    LOAD r0, "The number is negative."
+    JUMP done
+positive:
+    LOAD r0, "The number is positive but less than 100."
+    JUMP done
+large:
+    LOAD r0, "The number is positive and large!"
+done:
+    RETURN


### PR DESCRIPTION
Fixes issue #9

1. The C++ version erases all '\r' characters in each line read before being sent to the assembler.