### PR TITLE
C++ List Fixes

### DIFF
--- a/MS2Proto3/cpp/core/gc.c
+++ b/MS2Proto3/cpp/core/gc.c
@@ -46,7 +46,7 @@ GC gc = {0};
 
 // Forward declarations for marking functions
 void gc_mark_string(StringStorage* str);
-void gc_mark_list(List* list);
+void gc_mark_list(ValueList* list);
 
 void gc_init(void) {
     gc.all_objects = NULL;
@@ -162,7 +162,7 @@ void gc_mark_value(Value v) {
         StringStorage* str = as_string(v);
         if (str) gc_mark_string(str);
     } else if (is_list(v)) {
-        List* list = as_list(v);
+        ValueList* list = as_list(v);
         if (list) gc_mark_list(list);
     }
     // Numbers, ints, nil don't need marking
@@ -180,7 +180,7 @@ void gc_mark_string(StringStorage* str) {
     // Strings don't contain other Values, so we're done
 }
 
-void gc_mark_list(List* list) {
+void gc_mark_list(ValueList* list) {
     if (!list) return;
     
     // Get GC object header

--- a/MS2Proto3/cpp/core/value_list.c
+++ b/MS2Proto3/cpp/core/value_list.c
@@ -8,7 +8,7 @@
 // List creation and management
 Value make_list(int initial_capacity) {
     if (initial_capacity <= 0) initial_capacity = 8; // Default capacity
-    List* list = (List*)gc_allocate(sizeof(List) + initial_capacity * sizeof(Value));
+    ValueList* list = (ValueList*)gc_allocate(sizeof(ValueList) + initial_capacity * sizeof(Value));
     list->count = 0;
     list->capacity = initial_capacity;
     return LIST_MASK | ((uintptr_t)list & 0xFFFFFFFFFFFFULL);
@@ -19,24 +19,24 @@ Value make_empty_list(void) {
 }
 
 // List access
-List* as_list(Value v) {
+ValueList* as_list(Value v) {
     if (!is_list(v)) return NULL;
-    return (List*)(uintptr_t)(v & 0xFFFFFFFFFFFFULL);
+    return (ValueList*)(uintptr_t)(v & 0xFFFFFFFFFFFFULL);
 }
 
 int list_count(Value list_val) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     return list ? list->count : 0;
 }
 
 int list_capacity(Value list_val) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     return list ? list->capacity : 0;
 }
 
 // List element operations
 Value list_get(Value list_val, int index) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     if (list && index >= 0 && index < list->count) {
         return list->items[index];
     }
@@ -44,14 +44,14 @@ Value list_get(Value list_val, int index) {
 }
 
 void list_set(Value list_val, int index, Value item) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     if (list && index >= 0 && index < list->count) {
         list->items[index] = item;
     }
 }
 
 void list_push(Value list_val, Value item) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     if (!list) return;
     
     // Add item if there's space
@@ -64,14 +64,14 @@ void list_push(Value list_val, Value item) {
 }
 
 Value list_pop(Value list_val) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     if (!list || list->count <= 0) return make_null();
     
     return list->items[--list->count];
 }
 
 void list_insert(Value list_val, int index, Value item) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     if (!list || index < 0 || index > list->count) return;
     
     // Insert item if there's space
@@ -87,7 +87,7 @@ void list_insert(Value list_val, int index, Value item) {
 }
 
 void list_remove(Value list_val, int index) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     if (!list || index < 0 || index >= list->count) return;
     
     // Shift elements to the left
@@ -100,7 +100,7 @@ void list_remove(Value list_val, int index) {
 
 // List searching
 int list_indexOf(Value list_val, Value item, int start_pos) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     if (!list) return -1;
     
     if (start_pos < 0) start_pos = 0;
@@ -119,18 +119,18 @@ bool list_contains(Value list_val, Value item) {
 
 // List utilities
 void list_clear(Value list_val) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     if (list) {
         list->count = 0;
     }
 }
 
 Value list_copy(Value list_val) {
-    List* src = as_list(list_val);
+    ValueList* src = as_list(list_val);
     if (!src) return make_null();
     
     Value new_list = make_list(src->capacity);
-    List* dst = as_list(new_list);
+    ValueList* dst = as_list(new_list);
     
     dst->count = src->count;
     for (int i = 0; i < src->count; i++) {
@@ -143,13 +143,13 @@ Value list_copy(Value list_val) {
 
 // Check if list needs capacity expansion
 bool list_needs_expansion(Value list_val) {
-    List* list = as_list(list_val);
+    ValueList* list = as_list(list_val);
     return list && (list->count >= list->capacity);
 }
 
 // Create a new list with expanded capacity, copying all elements
 Value list_with_expanded_capacity(Value list_val) {
-    List* old_list = as_list(list_val);
+    ValueList* old_list = as_list(list_val);
     if (!old_list) return make_null();
     
     // Double the capacity (minimum of 2)
@@ -157,7 +157,7 @@ Value list_with_expanded_capacity(Value list_val) {
     if (new_capacity < 2) new_capacity = 2;
     
     // Allocate new list directly to avoid make_list's minimum capacity constraint
-    List* new_list = (List*)gc_allocate(sizeof(List) + new_capacity * sizeof(Value));
+    ValueList* new_list = (ValueList*)gc_allocate(sizeof(ValueList) + new_capacity * sizeof(Value));
     new_list->count = old_list->count;
     new_list->capacity = new_capacity;
     

--- a/MS2Proto3/cpp/core/value_list.h
+++ b/MS2Proto3/cpp/core/value_list.h
@@ -18,14 +18,14 @@ typedef struct {
     int count;       // Number of elements
     int capacity;    // Allocated capacity
     Value items[];   // Array of Values
-} List;
+} ValueList;
 
 // List creation and management
 Value make_list(int initial_capacity);
 Value make_empty_list(void);
 
 // List access
-List* as_list(Value v);
+ValueList* as_list(Value v);
 int list_count(Value list_val);
 int list_capacity(Value list_val);
 

--- a/MS2Proto3/cs/StringUtils.cs
+++ b/MS2Proto3/cs/StringUtils.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 // CPP: #include "IOHelper.g.h"
 // CPP: #include "value_string.h"
+// CPP: #include "value_list.h"
 // CPP: #include <sstream>
 // CPP: #include <cctype>
 
@@ -123,6 +124,15 @@ namespace MiniScript {
 			if (is_string(v)) {
 				const char* str = as_cstring(v);
 				return str ? String(str, pool) : String("<str?>", pool);
+			}
+			if (is_list(v)) {
+				std::ostringstream oss;
+				oss << "[";
+				for(int i = 0; i < list_count(v); i++) {
+					oss << (i != 0 ? ", " : "") << makeString(pool, list_get(v, i)).c_str();
+				}
+				oss << "]";
+				return String(oss.str().c_str(), pool);
 			}
 			std::ostringstream oss;
 			oss << "<value:0x" << std::hex << v << ">";

--- a/MS2Proto3/cs/VM.cs
+++ b/MS2Proto3/cs/VM.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 // CPP: #include "value.h"
+// CPP: #include "value_list.h"
 // CPP: #include "Bytecode.g.h"
 // CPP: #include "IOHelper.g.h"
 // CPP: #include "Disassembler.g.h"


### PR DESCRIPTION
Changes:

1. Fixed conflict between template class named List (that is supposed to mimic the C# List type), and the struct named List (which seems to be called ValueList in C#) by renaming the latter to ValueList.
2. Changed a bunch of references from List to ValueList. (**Note: Please double-check this one. I *think* I did this right, but if I didn't, the garbage collection is probably doomed.**)
3. Added inclusion of necessary headers to see list functions.
4. Added support for printing list contents, including lists of lists.

TODO:

1. Either make C# version print lists of lists, or remove this feature in the C++ version. As of now C# just prints `<list>` for an inner list.