### PR TITLE
Boolean storage opcodes

### DIFF
--- a/MS2Proto3/VM_DESIGN.md
+++ b/MS2Proto3/VM_DESIGN.md
@@ -8,6 +8,8 @@ The VM in this prototype is register (rather than stack) based.  Instructions ar
 
 Our internal opcode names include a verb/mnemonic, and a description of how the three operand bytes (A, B, and C) are used.  This allows us to overload the same verb with different variants that use the operands in different ways, and make it easy to remember what's going on with each one.
 
+### Basic loading, data, and math
+
 | Mnemonic | Description |
 | --- | --- |
 | NOOP | do nothing (but do it very quickly) |
@@ -23,7 +25,26 @@ Our internal opcode names include a verb/mnemonic, and a description of how the 
 | PUSH_rA_rB | push R[B] onto list R[A] |
 | INDEX_rA_rB_rC | R[A] := R[B][R[C]] (get element R[C] from list R[B]) |
 | IDXSET_rA_rB_rC | R[A][R[B]] := R[C] (set element R[B] of list R[A] to R[C]) |
+
+### Boolean Storage
+
+| Mnemonic | Description |
+| --- | --- |
 | LT_rA_rB_rC | R[A] := (R[B] < R[C]) |
+| LT_rA_rB_iC | R[A] := (R[B] < C (8-bit signed)) |
+| LT_rA_iB_rC | R[A] := (B (8-bit signed) < R[C]) |
+| LE_rA_rB_rC | R[A] := (R[B] <= R[C]) |
+| LE_rA_rB_iC | R[A] := (R[B] <= C (8-bit signed)) |
+| LE_rA_iB_rC | R[A] := (B (8-bit signed) <= R[C]) |
+| EQ_rA_rB_rC | R[A] := (R[B] == R[C]) |
+| EQ_rA_rB_iC | R[A] := (R[B] == C (8-bit signed)) |
+| NE_rA_rB_rC | R[A] := (R[B] != R[C]) |
+| NE_rA_rB_iC | R[A] := (R[B] != C (8-bit signed)) |
+
+### Flow Control
+
+| Mnemonic | Description |
+| --- | --- |
 | JUMP_iABC | PC += ABC (24-bit signed value) |
 | BRTRUE_rA_iBC | if R[A] is true then PC += BC (16-bit signed) |
 | BRFALSE_rA_iBC | if R[A] is false then PC += BC (16-bit signed) |

--- a/MS2Proto3/cpp/core/dispatch_macros.h
+++ b/MS2Proto3/cpp/core/dispatch_macros.h
@@ -35,6 +35,16 @@
 	X(INDEX_rA_rB_rC) \
 	X(IDXSET_rA_rB_rC) \
 	X(JUMP_iABC) \
+	X(LT_rA_rB_rC) \
+	X(LT_rA_rB_iC) \
+	X(LT_rA_iB_rC) \
+	X(LE_rA_rB_rC) \
+	X(LE_rA_rB_iC) \
+	X(LE_rA_iB_rC) \
+	X(EQ_rA_rB_rC) \
+	X(EQ_rA_rB_iC) \
+	X(NE_rA_rB_rC) \
+	X(NE_rA_rB_iC) \
 	X(BRTRUE_rA_iBC) \
 	X(BRFALSE_rA_iBC) \
 	X(BRLT_rA_rB_iC) \

--- a/MS2Proto3/cs/Assembler.cs
+++ b/MS2Proto3/cs/Assembler.cs
@@ -274,6 +274,90 @@ namespace MiniScript {
 					offset = ParseInt24(target);
 				}
 				instruction = BytecodeUtil.INS(Opcode.JUMP_iABC) | (UInt32)(offset & 0xFFFFFF);
+
+			} else if (mnemonic == "LT") {
+				if (parts.Count != 4) { Error("Syntax error"); return 0; }
+				
+				if (parts[3][0] == 'r') {
+					if (parts[2][0] == 'r') {
+						// LT r5, r3, r2  -->  LT_rA_rB_rC
+						Byte reg1 = ParseRegister(parts[1]);
+						Byte reg2 = ParseRegister(parts[2]);
+						Byte reg3 = ParseRegister(parts[3]);
+						instruction = BytecodeUtil.INS_ABC(Opcode.LT_rA_rB_rC, reg1, reg2, reg3);
+					}
+					else{
+						// LT r5, 15, r2  -->  LT_rA_iB_rC
+						Byte reg1 = ParseRegister(parts[1]);
+						Byte immediate = ParseByte(parts[2]);
+						Byte reg3 = ParseRegister(parts[3]);
+						instruction = BytecodeUtil.INS_ABC(Opcode.LT_rA_iB_rC, reg1, immediate, reg3);
+					}
+				} else {
+					// LT r5, r3, 15  -->  LT_rA_rB_iC
+					Byte reg1 = ParseRegister(parts[1]);
+					Byte reg2 = ParseRegister(parts[2]);
+					Byte immediate = ParseByte(parts[3]);
+					instruction = BytecodeUtil.INS_ABC(Opcode.LT_rA_rB_iC, reg1, reg2, immediate);
+				}
+
+			} else if (mnemonic == "LE") {
+				if (parts.Count != 4) { Error("Syntax error"); return 0; }
+				
+				if (parts[3][0] == 'r') {
+					if (parts[2][0] == 'r') {
+						// LT r5, r3, r2  -->  LT_rA_rB_rC
+						Byte reg1 = ParseRegister(parts[1]);
+						Byte reg2 = ParseRegister(parts[2]);
+						Byte reg3 = ParseRegister(parts[3]);
+						instruction = BytecodeUtil.INS_ABC(Opcode.LE_rA_rB_rC, reg1, reg2, reg3);
+					}
+					else{
+						// LT r5, 15, r2  -->  LT_rA_iB_rC
+						Byte reg1 = ParseRegister(parts[1]);
+						Byte immediate = ParseByte(parts[2]);
+						Byte reg3 = ParseRegister(parts[3]);
+						instruction = BytecodeUtil.INS_ABC(Opcode.LE_rA_iB_rC, reg1, immediate, reg3);
+					}
+				} else {
+					// LT r5, r3, 15  -->  LT_rA_rB_iC
+					Byte reg1 = ParseRegister(parts[1]);
+					Byte reg2 = ParseRegister(parts[2]);
+					Byte immediate = ParseByte(parts[3]);
+					instruction = BytecodeUtil.INS_ABC(Opcode.LE_rA_rB_iC, reg1, reg2, immediate);
+				}
+
+			} else if (mnemonic == "EQ") {
+				if (parts.Count != 4) { Error("Syntax error"); return 0; }
+
+				Byte reg1 = ParseRegister(parts[1]);
+				Byte reg2 = ParseRegister(parts[2]);
+
+				if (parts[3][0] == 'r') {
+					// EQ r5, r3, r2  -->  EQ_rA_rB_rC
+						Byte reg3 = ParseRegister(parts[3]);
+						instruction = BytecodeUtil.INS_ABC(Opcode.EQ_rA_rB_rC, reg1, reg2, reg3);
+				} else {
+					// EQ r5, r3, 15  -->  EQ_rA_rB_iC
+					Byte immediate = ParseByte(parts[3]);
+					instruction = BytecodeUtil.INS_ABC(Opcode.EQ_rA_rB_iC, reg1, reg2, immediate);
+				}
+
+			} else if (mnemonic == "NE") {
+				if (parts.Count != 4) { Error("Syntax error"); return 0; }
+
+				Byte reg1 = ParseRegister(parts[1]);
+				Byte reg2 = ParseRegister(parts[2]);
+
+				if (parts[3][0] == 'r') {
+					// NE r5, r3, r2  -->  NE_rA_rB_rC
+						Byte reg3 = ParseRegister(parts[3]);
+						instruction = BytecodeUtil.INS_ABC(Opcode.NE_rA_rB_rC, reg1, reg2, reg3);
+				} else {
+					// NE r5, r3, 15  -->  NE_rA_rB_iC
+					Byte immediate = ParseByte(parts[3]);
+					instruction = BytecodeUtil.INS_ABC(Opcode.NE_rA_rB_iC, reg1, reg2, immediate);
+				}
 			
 			} else if (mnemonic == "BRTRUE") {
 				if (parts.Count != 3) { Error("Syntax error"); return 0; }
@@ -529,11 +613,11 @@ namespace MiniScript {
 				Byte reg1 = ParseRegister(parts[1]);
 
 				if (parts[2][0] == 'r') {
-					// IFEQ r5, r3  -->  IFLE_rA_rB
+					// IFEQ r5, r3  -->  IFEQ_rA_rB
 						Byte reg2 = ParseRegister(parts[2]);
 						instruction = BytecodeUtil.INS_ABC(Opcode.IFEQ_rA_rB, reg1, reg2, 0);
 				} else {
-					// IFEQ r5, 42  -->  IFLE_rA_iBC
+					// IFEQ r5, 42  -->  IFEQ_rA_iBC
 					Int16 immediate = ParseInt16(parts[2]);
 					instruction = BytecodeUtil.INS_AB(Opcode.IFEQ_rA_iBC, reg1, immediate);
 				}
@@ -544,11 +628,11 @@ namespace MiniScript {
 				Byte reg1 = ParseRegister(parts[1]);
 
 				if (parts[2][0] == 'r') {
-					// IFEQ r5, r3  -->  IFLE_rA_rB
+					// IFNE r5, r3  -->  IFNE_rA_rB
 						Byte reg2 = ParseRegister(parts[2]);
 						instruction = BytecodeUtil.INS_ABC(Opcode.IFNE_rA_rB, reg1, reg2, 0);
 				} else {
-					// IFEQ r5, 42  -->  IFLE_rA_iBC
+					// IFNE r5, 42  -->  IFNE_rA_iBC
 					Int16 immediate = ParseInt16(parts[2]);
 					instruction = BytecodeUtil.INS_AB(Opcode.IFNE_rA_iBC, reg1, immediate);
 				}
@@ -584,6 +668,35 @@ namespace MiniScript {
 				return 0;
 			}
 			return (Byte)ParseInt16(reg.Substring(1));
+		}
+
+		// Helper to parse a Byte number (handles negative numbers)
+		private Byte ParseByte(String num) {
+			// Simple number parsing - could be enhanced
+			Int64 result = 0;
+			Boolean negative = false;
+			Int32 start = 0;
+			
+			if (num.Length > 0 && num[0] == '-') {
+				negative = true;
+				start = 1;
+			}
+			
+			for (Int32 i = start; i < num.Length; i++) {
+				if (num[i] >= '0' && num[i] <= '9') {
+					result = result * 10 + (num[i] - '0');
+				} else {
+					Error(StringUtils.Format("Invalid number format: '{0}' (unexpected character '{1}')", num, num[i]));
+					return 0;
+				}
+			}
+			
+			if (negative) result = -result;
+			if (result < Byte.MinValue || result > Byte.MaxValue) {
+				Error(StringUtils.Format("Number '{0}' is out of range for Int16 ({1} to {2})", num, Byte.MinValue, Byte.MaxValue));
+				return 0;
+			}
+			return (Byte)result;
 		}
 		
 		// Helper to parse an Int16 number (handles negative numbers)

--- a/MS2Proto3/cs/Bytecode.cs
+++ b/MS2Proto3/cs/Bytecode.cs
@@ -19,16 +19,16 @@ namespace MiniScript {
 		INDEX_rA_rB_rC,
 		IDXSET_rA_rB_rC,
 		JUMP_iABC,
-	//	LT_rA_rB,
-	//	LT_rA_iBC,
-	//	LT_iAB_rC,
-	//	LE_rA_rB,
-	//	LE_rA_iBC,
-	//	LE_iAB_rC,
-	//	EQ_rA_rB,
-	//	EQ_rA_iBC,
-	//	NE_rA_rB,
-	//	NE_rA_iBC,
+		LT_rA_rB_rC,
+		LT_rA_rB_iC,
+		LT_rA_iB_rC,
+		LE_rA_rB_rC,
+		LE_rA_rB_iC,
+		LE_rA_iB_rC,
+		EQ_rA_rB_rC,
+		EQ_rA_rB_iC,
+		NE_rA_rB_rC,
+		NE_rA_rB_iC,
 		BRTRUE_rA_iBC,
 		BRFALSE_rA_iBC,
 		BRLT_rA_rB_iC,
@@ -109,6 +109,16 @@ namespace MiniScript {
 				case Opcode.INDEX_rA_rB_rC: return "INDEX_rA_rB_rC";
 				case Opcode.IDXSET_rA_rB_rC:return "IDXSET_rA_rB_rC";
 				case Opcode.JUMP_iABC:      return "JUMP_iABC";
+				case Opcode.LT_rA_rB_rC:    return "LT_rA_rB_rC";
+				case Opcode.LT_rA_rB_iC:    return "LT_rA_rB_iC";
+				case Opcode.LT_rA_iB_rC:    return "LT_rA_iB_rC";
+				case Opcode.LE_rA_rB_rC:    return "LE_rA_rB_rC";
+				case Opcode.LE_rA_rB_iC:    return "LE_rA_rB_iC";
+				case Opcode.LE_rA_iB_rC:    return "LE_rA_iB_rC";
+				case Opcode.EQ_rA_rB_rC:    return "EQ_rA_rB_rC";
+				case Opcode.EQ_rA_rB_iC:    return "EQ_rA_rB_iC";
+				case Opcode.NE_rA_rB_rC:    return "NE_rA_rB_rC";
+				case Opcode.NE_rA_rB_iC:    return "NE_rA_rB_iC";
 				case Opcode.BRTRUE_rA_iBC:  return "BRTRUE_rA_iBC";
 				case Opcode.BRFALSE_rA_iBC: return "BRFALSE_rA_iBC";
 				case Opcode.BRLT_rA_rB_iC:  return "BRLT_rA_rB_iC";
@@ -153,6 +163,16 @@ namespace MiniScript {
 			if (s == "INDEX_rA_rB_rC")  return Opcode.INDEX_rA_rB_rC;
 			if (s == "IDXSET_rA_rB_rC") return Opcode.IDXSET_rA_rB_rC;
 			if (s == "JUMP_iABC")       return Opcode.JUMP_iABC;
+			if (s == "LT_rA_rB_rC")     return Opcode.LT_rA_rB_rC;
+			if (s == "LT_rA_rB_iC")     return Opcode.LT_rA_rB_iC;
+			if (s == "LT_rA_iB_rC")     return Opcode.LT_rA_iB_rC;
+			if (s == "LE_rA_rB_rC")     return Opcode.LE_rA_rB_rC;
+			if (s == "LE_rA_rB_iC")     return Opcode.LE_rA_rB_iC;
+			if (s == "LE_rA_iB_rC")     return Opcode.LE_rA_iB_rC;
+			if (s == "EQ_rA_rB_rC")     return Opcode.EQ_rA_rB_rC;
+			if (s == "EQ_rA_rB_iC")     return Opcode.EQ_rA_rB_iC;
+			if (s == "NE_rA_rB_rC")     return Opcode.NE_rA_rB_rC;
+			if (s == "NE_rA_rB_iC")     return Opcode.NE_rA_rB_iC;
 			if (s == "BRTRUE_rA_iBC")   return Opcode.BRTRUE_rA_iBC;
 			if (s == "BRFALSE_rA_iBC")  return Opcode.BRFALSE_rA_iBC;
 			if (s == "BRLT_rA_rB_iC")   return Opcode.BRLT_rA_rB_iC;

--- a/MS2Proto3/cs/Disassembler.cs
+++ b/MS2Proto3/cs/Disassembler.cs
@@ -25,6 +25,16 @@ namespace MiniScript {
 				case Opcode.IDXSET_rA_rB_rC: return "IDXSET";
 				case Opcode.SUB_rA_rB_rC:  return "SUB";
 				case Opcode.JUMP_iABC:     return "JUMP";
+				case Opcode.LT_rA_rB_rC:
+				case Opcode.LT_rA_rB_iC:
+				case Opcode.LT_rA_iB_rC:   return "LT";
+				case Opcode.LE_rA_rB_rC:
+				case Opcode.LE_rA_rB_iC:
+				case Opcode.LE_rA_iB_rC:   return "LE";
+				case Opcode.EQ_rA_rB_rC:
+				case Opcode.EQ_rA_rB_iC:   return "EQ";
+				case Opcode.NE_rA_rB_rC:
+				case Opcode.NE_rA_rB_iC:   return "NE";
 				case Opcode.BRTRUE_rA_iBC: return "BCTRUE";
 				case Opcode.BRFALSE_rA_iBC:return "BCFALSE";
 				case Opcode.BRLT_rA_rB_iC:
@@ -126,6 +136,10 @@ namespace MiniScript {
 				case Opcode.MULT_rA_rB_rC:
 				case Opcode.DIV_rA_rB_rC:
 				case Opcode.MOD_rA_rB_rC:
+				case Opcode.LT_rA_rB_rC:
+				case Opcode.LE_rA_rB_rC:
+				case Opcode.EQ_rA_rB_rC:
+				case Opcode.NE_rA_rB_rC:
 				case Opcode.INDEX_rA_rB_rC:
 				case Opcode.IDXSET_rA_rB_rC:
         			return StringUtils.Format("{0} r{1}, r{2}, r{3}",
@@ -134,6 +148,10 @@ namespace MiniScript {
         				(Int32)BytecodeUtil.Bu(instruction),
         				(Int32)BytecodeUtil.Cu(instruction));
 				// rA, rB, iC
+				case Opcode.LT_rA_rB_iC:
+				case Opcode.LE_rA_rB_iC:
+				case Opcode.EQ_rA_rB_iC:
+				case Opcode.NE_rA_rB_iC:
 				case Opcode.BRLT_rA_rB_iC:
 				case Opcode.BRLE_rA_rB_iC:
 				case Opcode.BREQ_rA_rB_iC:
@@ -157,6 +175,14 @@ namespace MiniScript {
 				case Opcode.BRLT_iA_rB_iC:
 				case Opcode.BRLE_iA_rB_iC:
 					return StringUtils.Format("{0} {1}, r{2}, {3}",
+        				mnemonic,
+        				(Int32)BytecodeUtil.Au(instruction),
+        				(Int32)BytecodeUtil.Bu(instruction),
+        				(Int32)BytecodeUtil.Cu(instruction));
+				// rA, iB, rC
+				case Opcode.LT_rA_iB_rC:
+				case Opcode.LE_rA_iB_rC:
+					return StringUtils.Format("{0} r{1}, {2}, r{3}",
         				mnemonic,
         				(Int32)BytecodeUtil.Au(instruction),
         				(Int32)BytecodeUtil.Bu(instruction),

--- a/MS2Proto3/cs/VM.cs
+++ b/MS2Proto3/cs/VM.cs
@@ -272,6 +272,106 @@ namespace MiniScript {
 						break; // CPP: VM_NEXT();
 					}
 
+					case Opcode.LT_rA_rB_rC: { // CPP: VM_CASE(LT_rA_rB_rC) {
+						// if R[A] = R[B] < R[C]
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						Byte c = BytecodeUtil.Cu(instruction);
+
+						stack[baseIndex + a] = make_int(value_lt(stack[baseIndex + b], stack[baseIndex + c]));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.LT_rA_rB_iC: { // CPP: VM_CASE(LT_rA_rB_iC) {
+						// if R[A] = R[B] < C (immediate)
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						SByte c = BytecodeUtil.Cs(instruction);
+						
+						stack[baseIndex + a] = make_int(value_lt(stack[baseIndex + b], make_int(c)));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.LT_rA_iB_rC: { // CPP: VM_CASE(LT_rA_iB_rC) {
+						// if R[A] = B (immediate) < R[C]
+						Byte a = BytecodeUtil.Au(instruction);
+						SByte b = BytecodeUtil.Bs(instruction);
+						Byte c = BytecodeUtil.Cu(instruction);
+						
+						stack[baseIndex + a] = make_int(value_lt(make_int(b), stack[baseIndex + c]));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.LE_rA_rB_rC: { // CPP: VM_CASE(LE_rA_rB_rC) {
+						// if R[A] = R[B] <= R[C]
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						Byte c = BytecodeUtil.Cu(instruction);
+
+						stack[baseIndex + a] = make_int(value_le(stack[baseIndex + b], stack[baseIndex + c]));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.LE_rA_rB_iC: { // CPP: VM_CASE(LE_rA_rB_iC) {
+						// if R[A] = R[B] <= C (immediate)
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						SByte c = BytecodeUtil.Cs(instruction);
+						
+						stack[baseIndex + a] = make_int(value_le(stack[baseIndex + b], make_int(c)));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.LE_rA_iB_rC: { // CPP: VM_CASE(LE_rA_iB_rC) {
+						// if R[A] = B (immediate) <= R[C]
+						Byte a = BytecodeUtil.Au(instruction);
+						SByte b = BytecodeUtil.Bs(instruction);
+						Byte c = BytecodeUtil.Cu(instruction);
+						
+						stack[baseIndex + a] = make_int(value_le(make_int(b), stack[baseIndex + c]));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.EQ_rA_rB_rC: { // CPP: VM_CASE(EQ_rA_rB_rC) {
+						// if R[A] = R[B] == R[C]
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						Byte c = BytecodeUtil.Cu(instruction);
+
+						stack[baseIndex + a] = make_int(value_equal(stack[baseIndex + b], stack[baseIndex + c]));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.EQ_rA_rB_iC: { // CPP: VM_CASE(EQ_rA_rB_iC) {
+						// if R[A] = R[B] == C (immediate)
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						SByte c = BytecodeUtil.Cs(instruction);
+						
+						stack[baseIndex + a] = make_int(value_equal(stack[baseIndex + b], make_int(c)));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.NE_rA_rB_rC: { // CPP: VM_CASE(NE_rA_rB_rC) {
+						// if R[A] = R[B] != R[C]
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						Byte c = BytecodeUtil.Cu(instruction);
+
+						stack[baseIndex + a] = make_int(!value_equal(stack[baseIndex + b], stack[baseIndex + c]));
+						break; // CPP: VM_NEXT();
+					}
+
+					case Opcode.NE_rA_rB_iC: { // CPP: VM_CASE(NE_rA_rB_iC) {
+						// if R[A] = R[B] != C (immediate)
+						Byte a = BytecodeUtil.Au(instruction);
+						Byte b = BytecodeUtil.Bu(instruction);
+						SByte c = BytecodeUtil.Cs(instruction);
+						
+						stack[baseIndex + a] = make_int(!value_equal(stack[baseIndex + b], make_int(c)));
+						break; // CPP: VM_NEXT();
+					}
+
 					case Opcode.BRTRUE_rA_iBC: { // CPP: VM_CASE(BRTRUE_rA_iBC) {
 						Byte a = BytecodeUtil.Au(instruction);
 						Int32 offset = BytecodeUtil.BCs(instruction);

--- a/MS2Proto3/cs/Value.cs
+++ b/MS2Proto3/cs/Value.cs
@@ -316,6 +316,9 @@ namespace MiniScript {
 		
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Value make_int(int i) => Value.FromInt(i);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Value make_int(bool b) => Value.FromInt(b ? 1 : 0);
 		
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Value make_double(double d) => Value.FromDouble(d);


### PR DESCRIPTION
- Added the boolean storage opcodes (ie. LT, LE, EQ, and NE)
- Added overload `make_int(bool)` since C# doesn't like converting implicitly from bool to int
- Updated opcode documentation and split up the raw opcodes into relevant sections for (hopefully) easier reading