### PR TITLE
C++ Unicode Fix

### DIFF
--- a/MS2Proto3/cs/Assembler.cs
+++ b/MS2Proto3/cs/Assembler.cs
@@ -724,7 +724,7 @@ namespace MiniScript {
 
 		// Helper to check if a token is a string literal (surrounded by quotes)
 		private static Boolean IsStringLiteral(String token) {
-			return token.Length >= 2 && token[0] == '"' && token[token.Length - 1] == '"';
+			return token.Length >= 2 && token[0] == '"' && token[token.Length - 1] == '"'; // CPP: return token.lengthB() >= 2 && token[0] == '"' && token[token.lengthB() - 1] == '"'; // C++ indexes into the bytes, so we need to use lengthB() or change indexing to be character-based.
 		}
 
 		// Helper to check if a token needs to be stored as a constant


### PR DESCRIPTION
- Changed C++ version of IsStringLiteral() to check the byte-length of string instead of its character-length. Alternatively, we could theoretically switch to character indexing (as C# does it), but this seemed simpler at the time.

This fixes the issue of C++ not being able to read assembly files with non-ASCII characters in the strings.