### PR TITLE
String Math

### DIFF
--- a/MS2Proto3/cpp/core/value.c
+++ b/MS2Proto3/cpp/core/value.c
@@ -256,20 +256,14 @@ Value value_shl(Value v, int shift) {
 // Conversion functions
 
 
-// Note: This is probably the most dangerous function currently in MiniScript as of this date: 9/12/2025.
-// If there is any sign of buffer overflows, this function should be checked, and rechecked -- just because
-// of the nature of working with C-strings. We're copying MiniScript 1.0's implementation and tweaking it
-// a little to be in line with the new MS2Proto3 design.
-// 
-// ~ BC
-//
 // TODO: Consider inlining this.
 // TODO: Add support for lists and maps
+// Using raw C-String
 Value to_string(Value v){
     char buf[32];
 
-    if(is_tiny_string(v) || is_heap_string(v)) return v;
-    if(is_double(v)) {
+    if (is_string(v)) return v;
+    if (is_double(v)) {
         double value = as_double(v);
         if (fmod(value, 1.0) == 0.0) {
             snprintf(buf, sizeof buf, "%.0f", value);
@@ -288,17 +282,16 @@ Value to_string(Value v){
                 //if (i+1 < s.LengthB()) s = s.SubstringB(0, i+1);
                 //
             // Converted code:
-            char *ptr = &buf[0];
             size_t i;
 
             snprintf(buf, sizeof buf, "%.6f", value);
             i = strlen(buf) - 1;
             while (i > 1 && buf[i] == '0' && buf[i-1] != '.') i--;
-            if (i+1 < strlen(buf)) ptr = &buf[i+1];
-            return make_string(ptr);
+            if (i+1 < strlen(buf)) buf[i+1] = '\0';
+            return make_string(buf);
         }
     }
-    else if(is_int(v)) {
+    else if (is_int(v)) {
         snprintf(buf, sizeof buf, "%d", as_int(v));
         return make_string(buf);
     }

--- a/MS2Proto3/cpp/core/value.h
+++ b/MS2Proto3/cpp/core/value.h
@@ -132,6 +132,11 @@ extern Value make_string(const char* str);
 extern const char* get_string_data_zerocopy(const Value* v_ptr, int* out_len);
 extern int string_compare(Value a, Value b);
 
+// Conversion functions
+
+Value to_string(Value v);
+Value to_number(Value v); // TODO: implement this
+
 // Arithmetic operations (inlined for performance)
 static inline Value value_add(Value a, Value b) {
     // Handle integer + integer case
@@ -154,8 +159,12 @@ static inline Value value_add(Value a, Value b) {
     }
     
     // Handle string concatenation
-    if (is_string(a) && is_string(b)) {
-        return string_concat(a, b);
+
+    if (is_string(a)) {
+        if (is_string(b)) return string_concat(a, b);
+        if (is_int(b) || is_double(b)) return string_concat(a, to_string(b));
+	} else if (is_string(b)) {
+        if (is_int(a) || is_double(a)) return string_concat(to_string(a), b);
     }
     
     // For now, return nil for unsupported operations

--- a/MS2Proto3/cs/Assembler.cs
+++ b/MS2Proto3/cs/Assembler.cs
@@ -724,7 +724,7 @@ namespace MiniScript {
 
 		// Helper to check if a token is a string literal (surrounded by quotes)
 		private static Boolean IsStringLiteral(String token) {
-			return token.Length >= 2 && token[0] == '"' && token[token.Length - 1] == '"';
+			return token.Length >= 2 && token[0] == '"' && token[token.Length - 1] == '"'; // CPP: return token.lengthB() >= 2 && token[0] == '"' && token[token.lengthB() - 1] == '"'; // C++ indexes into the bytes, so we need to use lengthB() or change indexing to be character-based.
 		}
 
 		// Helper to check if a token needs to be stored as a constant

--- a/MS2Proto3/cs/VM.cs
+++ b/MS2Proto3/cs/VM.cs
@@ -275,7 +275,7 @@ namespace MiniScript {
 					case Opcode.BRTRUE_rA_iBC: { // CPP: VM_CASE(BRTRUE_rA_iBC) {
 						Byte a = BytecodeUtil.Au(instruction);
 						Int32 offset = BytecodeUtil.BCs(instruction);
-						if(is_truthy(stack[baseIndex + a])){
+						if (is_truthy(stack[baseIndex + a])){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -284,7 +284,7 @@ namespace MiniScript {
 					case Opcode.BRFALSE_rA_iBC: { // CPP: VM_CASE(BRFALSE_rA_iBC) {
 						Byte a = BytecodeUtil.Au(instruction);
 						Int32 offset = BytecodeUtil.BCs(instruction);
-						if(!is_truthy(stack[baseIndex + a])){
+						if (!is_truthy(stack[baseIndex + a])){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -295,7 +295,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						Byte b = BytecodeUtil.Bu(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(value_lt(stack[baseIndex + a], stack[baseIndex + b])){
+						if (value_lt(stack[baseIndex + a], stack[baseIndex + b])){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -306,7 +306,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						SByte b = BytecodeUtil.Bs(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(value_lt(stack[baseIndex + a], make_int(b))){
+						if value_lt(stack[baseIndex + a], make_int(b))){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -317,7 +317,7 @@ namespace MiniScript {
 						SByte a = BytecodeUtil.As(instruction);
 						Byte b = BytecodeUtil.Bu(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(value_lt(make_int(a), stack[baseIndex + b])){
+						if (value_lt(make_int(a), stack[baseIndex + b])){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -328,7 +328,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						Byte b = BytecodeUtil.Bu(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(value_le(stack[baseIndex + a], stack[baseIndex + b])){
+						if (value_le(stack[baseIndex + a], stack[baseIndex + b])){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -339,7 +339,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						SByte b = BytecodeUtil.Bs(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(value_le(stack[baseIndex + a], make_int(b))){
+						if (value_le(stack[baseIndex + a], make_int(b))){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -350,7 +350,7 @@ namespace MiniScript {
 						SByte a = BytecodeUtil.As(instruction);
 						Byte b = BytecodeUtil.Bu(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(value_le(make_int(a), stack[baseIndex + b])){
+						if (value_le(make_int(a), stack[baseIndex + b])){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -361,7 +361,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						Byte b = BytecodeUtil.Bu(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(value_equal(stack[baseIndex + a], stack[baseIndex + b])){
+						if (value_equal(stack[baseIndex + a], stack[baseIndex + b])){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -372,7 +372,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						SByte b = BytecodeUtil.Bs(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(value_equal(stack[baseIndex + a], make_int(b))){
+						if (value_equal(stack[baseIndex + a], make_int(b))){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -383,7 +383,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						Byte b = BytecodeUtil.Bu(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(!value_equal(stack[baseIndex + a], stack[baseIndex + b])){
+						if (!value_equal(stack[baseIndex + a], stack[baseIndex + b])){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();
@@ -394,7 +394,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						SByte b = BytecodeUtil.Bs(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if(!value_equal(stack[baseIndex + a], make_int(b))){
+						if (!value_equal(stack[baseIndex + a], make_int(b))){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();

--- a/MS2Proto3/cs/Value.cs
+++ b/MS2Proto3/cs/Value.cs
@@ -166,9 +166,12 @@ namespace MiniScript {
 				return FromDouble(da + db);
 			}
 			// Handle string concatenation
-			if (a.IsString && b.IsString) {
-				return StringOperations.StringConcat(a, b);
-			}
+			if (a.IsString) {
+                if (b.IsString) return StringOperations.StringConcat(a, b);
+                if (b.IsInt || b.IsDouble) return StringOperations.StringConcat(a, ValueHelpers.make_string(b.ToString()));
+			} else if(b.IsString) {
+                if (a.IsInt || a.IsDouble) return StringOperations.StringConcat(ValueHelpers.make_string(a.ToString()), b);
+            }
 			// string concat, list append, etc. can be added here.
 			return Null();
 		}
@@ -186,6 +189,21 @@ namespace MiniScript {
 				return FromDouble(da * db);
 			}
 			// TODO: String support not added yet!
+
+            // Handle string repetition: string * int or int * string
+            if (a.IsString && b.IsInt) {
+                int count = b.AsInt();
+                if (count <= 0) return FromString("");
+                if (count == 1) return a;
+                
+                // Build repeated string
+                Value result = a;
+                for (int i = 1; i < count; i++) {
+                    result = StringOperations.StringConcat(result, a);
+                }
+                return result;
+                // ToDo: handle fractional b.
+            }
 			// string concat, list append, etc. can be added here.
 			return Null();
 		}
@@ -424,6 +442,10 @@ namespace MiniScript {
 		// Comparison operations (matching value.h)
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool value_equal(Value a, Value b) => Value.Equal(a, b);		
+
+        // Conversion operations (matching value.h)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Value to_string(Value a) => make_string(a.ToString());
 	}
 
 	// A minimal, fast handle table. Stores actual C# objects referenced by Value.

--- a/MS2Proto3/examples/test_strings.msa
+++ b/MS2Proto3/examples/test_strings.msa
@@ -14,6 +14,28 @@
 	LOAD r0, 0  # all good!
 	RETURN
 
+@testConcatNumber:
+	# "abc" + 1 == "abc1"
+	LOAD r0, "String Concat Number (string + number)"
+	LOAD r1, "abc"
+	LOAD r2, 1
+	ADD r1, r1, r2
+	LOAD r3, "abc1"
+	IFNE r1, r3
+	RETURN
+
+	# 1 + "abc" == "1abc"
+	LOAD r0, "String Concat Number (number + string)"
+	LOAD r1, "abc"
+	LOAD r2, 1
+	ADD r1, r2, r1
+	LOAD r3, "1abc"
+	IFNE r1, r3
+	RETURN
+
+	LOAD r0, 0  # all good!
+	RETURN
+
 
 @testMult:
 	# "abc" * 2 == "abcabc"
@@ -40,6 +62,8 @@
 
 @main:
 	CALLF 0, @testConcat
+	BRTRUE r0, error
+	CALLF 0, @testConcatNumber
 	BRTRUE r0, error
 	CALLF 0, @testMult
 	BRTRUE r0, error


### PR DESCRIPTION
Changes:

1. Added `to_string()` helper function.
2. Implemented the C++ version of the above for conversion based on MiniScript 1.0's methodology.
3. Implemented (string+num) and (num+string) for C# and C++.
4. Implemented (string*int) for C# (to match C++ version that was already done).

TODO:

1. Add `to_number()` implementation (C++ already has a definition for it in value.h).
2. Continue (string*number) in both versions when the number is a fractional amount.