### PR TITLE
String fractional math

### DIFF
--- a/MS2Proto3/cpp/core/value.c
+++ b/MS2Proto3/cpp/core/value.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <limits.h>
+#include <math.h>
 
 // Debug utilities for Value inspection
 void debug_print_value(Value v) {
@@ -91,7 +92,22 @@ Value value_mult(Value a, Value b) {
             result = string_concat(result, a);
         }
         return result;
-        // ToDo: handle fractional b.
+    } else if (is_string(a) && is_double(b)) {
+        int repeats = 0;
+        int extraChars = 0;
+        double factor = as_double(b);
+        int factorClass = fpclassify(factor);
+        if (factorClass == FP_NAN || factorClass == FP_INFINITE) return make_null();
+        if (factorClass <= 0) return make_string("");
+
+        repeats = (int)factor;
+        Value result = make_string("");
+        for (int i = 0; i < repeats; i++) {
+            result = string_concat(result, a);
+        }
+        extraChars = (int)(string_length(a) * (factor - repeats));
+        if (extraChars > 0) result = string_concat(result, string_substring(a, 0, extraChars));
+        return result;
     }
     
     // For now, return nil for unsupported operations
@@ -116,6 +132,23 @@ Value value_div(Value a, Value b) {
         double da = is_int(a) ? (double)as_int(a) : as_double(a);
         double db = is_int(b) ? (double)as_int(b) : as_double(b);
         return make_double(da / db);
+    // Handle string / number
+    } else if (is_string(a) && is_number(b)) {
+        int repeats = 0;
+        int extraChars = 0;
+        double factor = 1 / (is_double(b) ? as_double(b) : (double)as_int(b));
+        int factorClass = fpclassify(factor);
+        if (factorClass == FP_NAN || factorClass == FP_INFINITE) return make_null();
+        if (factorClass <= 0) return make_string("");
+
+        repeats = (int)factor;
+        Value result = make_string("");
+        for (int i = 0; i < repeats; i++) {
+            result = string_concat(result, a);
+        }
+        extraChars = (int)(string_length(a) * (factor - repeats));
+        if (extraChars > 0) result = string_concat(result, string_substring(a, 0, extraChars));
+        return result;
     }
     
     // TODO: Handle string concatenation, etc.

--- a/MS2Proto3/cpp/core/value_string.h
+++ b/MS2Proto3/cpp/core/value_string.h
@@ -31,6 +31,7 @@ Value string_concat(Value a, Value b);
 int string_indexOf(Value haystack, Value needle, int start_pos);
 Value string_replace(Value source, Value search, Value replacement);
 Value string_split(Value str, Value delimiter);
+Value string_substring(Value str, int startIndex, int len);
 
 // Zero-copy string data access (for performance-critical operations)
 const char* get_string_data_zerocopy(const Value* v_ptr, int* out_len);

--- a/MS2Proto3/cs/VM.cs
+++ b/MS2Proto3/cs/VM.cs
@@ -406,7 +406,7 @@ namespace MiniScript {
 						Byte a = BytecodeUtil.Au(instruction);
 						SByte b = BytecodeUtil.Bs(instruction);
 						SByte offset = BytecodeUtil.Cs(instruction);
-						if value_lt(stack[baseIndex + a], make_int(b))){
+						if (value_lt(stack[baseIndex + a], make_int(b))){
 							pc += offset;
 						}
 						break; // CPP: VM_NEXT();


### PR DESCRIPTION
1. Fixed accidental removal of '(' in last PR.
2. Added support for string fractional math. (ie. `"abc" / 0.5 == "abcabc"`)
3. Added `string_substring()` defintion to value_string.h. (The function already was implemented in value_string.c, but it was not exposed.)
4. Added `using` clause for ValueHelpers and StringOperations in Value.cs. This means we can write Value implementations in C# just like C++ by using the helper functions.

TODO:

1. Refactor Value.cs to use the globals consistently (or switch to another methodology).
2. Consider evaluating performance of string operations. Concatenating character by character might be slow using the underlying Value class.
3. We might be able to use the in-house Value checks for NAN and Infinity instead of relying on standard library functionality in both languages (at least in some places).
4. Determine if we need to check max length of a string like MiniScript 1.0 does. Currently neither version checks when doing fractional math.