### PR TITLE
MiniScript 1.0 Added to Benchmark

### DIFF
--- a/MS2Proto3/examples/test_strings.msa
+++ b/MS2Proto3/examples/test_strings.msa
@@ -60,12 +60,37 @@
 	LOAD r0, 0
 	RETURN
 
+@testDiv:
+	# "abc" * 2 == "abcabc"
+	LOAD r0, "String / 2"
+	LOAD r1, "abcdef"
+	LOAD r2, 2
+	DIV r1, r1, r2
+	LOAD r3, "abc"
+	IFNE r1, r3
+	RETURN
+	
+	# "abcdef" * 0.5 = "abc"
+	LOAD r0, "String / 0.5"
+	LOAD r1, "abcdef"
+	LOAD r2, 0.5
+	DIV r1, r1, r2
+	LOAD r3, "abcdefabcdef"
+	IFNE r1, r3
+	RETURN
+	
+	# All good!
+	LOAD r0, 0
+	RETURN
+
 @main:
 	CALLF 0, @testConcat
 	BRTRUE r0, error
 	CALLF 0, @testConcatNumber
 	BRTRUE r0, error
 	CALLF 0, @testMult
+	BRTRUE r0, error
+	CALLF 0, @testDiv
 	BRTRUE r0, error
 	LOAD r0, "✅ All tests passed!"
 	RETURN

--- a/MS2Proto3/tools/examples/factorial_iterative.ms
+++ b/MS2Proto3/tools/examples/factorial_iterative.ms
@@ -1,0 +1,13 @@
+for i in range(1,750000)
+    factorial = 20 // Do not set this < 2. Yes, we are cheating here and still slow.
+    answer = 20
+
+    while factorial > 2
+        factorial -= 1
+        answer *= factorial
+    end while
+end for
+
+print "Result in r0:"
+print answer
+return answer

--- a/MS2Proto3/tools/examples/iter_fib.ms
+++ b/MS2Proto3/tools/examples/iter_fib.ms
@@ -2,12 +2,7 @@ for i in range (1, 500000)
     n = 30
     answer = 0
 
-    if n < 1 then
-        continue
-    end if
-    if n < 2 then
-        continue
-    end if
+    if n < 2 then continue
 
     a = 0
     b = 1

--- a/MS2Proto3/tools/examples/iter_fib.ms
+++ b/MS2Proto3/tools/examples/iter_fib.ms
@@ -1,0 +1,24 @@
+for i in range (1, 500000)
+    n = 30
+    answer = 0
+
+    if n < 1 then
+        continue
+    end if
+    if n < 2 then
+        continue
+    end if
+
+    a = 0
+    b = 1
+
+    for j in range(2, n)
+        c = a + b
+        a = b
+        b = c
+    end for
+    answer = b
+end for
+
+print "Result in r0:"
+print answer

--- a/MS2Proto3/tools/examples/recur_fib.ms
+++ b/MS2Proto3/tools/examples/recur_fib.ms
@@ -1,0 +1,9 @@
+// Recursive Fibonacci sequence.
+
+rfib = function(n)
+    if n < 2 then return n // No negatives please
+    return rfib(n-1) + rfib(n-2)
+end function
+
+print "Result in r0:"
+print rfib(33)


### PR DESCRIPTION
Changes:

1. Added slightly more involved div test that didn't make it in last PR (oops). (Feel free to ignore this one if you want.)
2. Removed `-o` flag from grep in tools/benchmark.sh. (This fixes the issue in Linux/WSL that breaks the benchmark.)
3. Added MiniScript 1.0 testing. It expects command line MiniScript to be available.
4. Added to expectation for factorial_iterative to include the long-form of the number printed, to match the Linux version of MiniScript command-line.
5. Tests now are loaded without file extensions in the benchmarks array, and extensions are now applied in `run_benchmark()` depending on the benchmark being executed.

Procedural notes:

1. MiniScript benchmark equivalents will need to be loaded in `tools/examples` with the same filenames as the other benchmarks, but with the `.ms` extension. For example, if you're testing the new MiniScript assembly file "examples/loop.msa" then you also need the MiniScript 1.0 equivalent at "tools/examples/loop.ms".
2. MiniScript benchmarks currently still have to print "Result in r0:" just to be consistent for grep to find. Perhaps we want to change this in the future.