### PR TITLE
Python + Lua benchmark additions

### DIFF
--- a/MS2Proto3/tools/benchmark.sh
+++ b/MS2Proto3/tools/benchmark.sh
@@ -206,8 +206,8 @@ echo ""
 # Clean markdown-style summary table
 echo -e "${BOLD}=== Performance Summary ===${NC}"
 echo ""
-echo "| Benchmark               | C#        | C++ (switch) | C++ (goto) | MiniScript 1.0 | Python |  Lua  |"
-echo "|-------------------------|-----------|--------------|------------|----------------|--------|-------|"
+echo "| Benchmark               | C#        | C++ (switch) | C++ (goto) |  MS 1.0  |  Python  |   Lua    |"
+echo "|-------------------------|-----------|--------------|------------|----------|----------|----------|"
 
 for i in "${!BENCHMARKS[@]}"; do
     IFS=':' read -r file name expected <<< "${BENCHMARKS[i]}"
@@ -218,7 +218,7 @@ for i in "${!BENCHMARKS[@]}"; do
     py_time="${PY_TIMES[i]}"
     lua_time="${LUA_TIMES[i]}"
     
-    printf "| %-23s | %-9s | %-12s | %-10s | %-14s | %-6s | %-5s |\n" "$name" "${cs_time}s" "${cpp_switch_time}s" "${cpp_goto_time}s" "${ms1_time}s" "${py_time}s" "${lua_time}s"
+    printf "| %-23s | %-9s | %-12s | %-10s | %-8s | %-8s | %-8s |\n" "$name" "${cs_time}s" "${cpp_switch_time}s" "${cpp_goto_time}s" "${ms1_time}s" "${py_time}s" "${lua_time}s"
 done
 
 echo ""

--- a/MS2Proto3/tools/examples/factorial_iterative.lua
+++ b/MS2Proto3/tools/examples/factorial_iterative.lua
@@ -1,0 +1,12 @@
+for i = 1, 750000, 1 do
+    factorial = 20 -- Do not set this < 2. Yes, we are cheating here, just like in MiniScript
+    answer = 20
+
+    while factorial > 2 do
+        factorial = factorial - 1
+        answer = answer * factorial
+    end
+end
+
+print("Result in r0:")
+print(answer)

--- a/MS2Proto3/tools/examples/factorial_iterative.py
+++ b/MS2Proto3/tools/examples/factorial_iterative.py
@@ -1,0 +1,10 @@
+for i in range(750000):
+    factorial = 20 # Do not set this < 2. Yes, we are cheating here, just like in MiniScript
+    answer = 20
+
+    while factorial > 2:
+        factorial -= 1
+        answer *= factorial
+
+print("Result in r0:")
+print(answer)

--- a/MS2Proto3/tools/examples/iter_fib.lua
+++ b/MS2Proto3/tools/examples/iter_fib.lua
@@ -1,0 +1,18 @@
+for i = 1, 500000, 1 do
+    n = 30 -- fib(30)
+    answer = 0
+
+    if n >= 2 then
+        a = 0
+        b = 1
+
+        for j = 2, n, 1 do
+            c = a + b
+            a = b
+            b = c
+        end
+        answer = b
+    end 
+end
+print("Result in r0:")
+print(answer)

--- a/MS2Proto3/tools/examples/iter_fib.ms
+++ b/MS2Proto3/tools/examples/iter_fib.ms
@@ -1,5 +1,5 @@
 for i in range (1, 500000)
-    n = 30
+    n = 30 // fib(30)
     answer = 0
 
     if n < 2 then continue

--- a/MS2Proto3/tools/examples/iter_fib.py
+++ b/MS2Proto3/tools/examples/iter_fib.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+for i in range(500000):
+    n = 30 # fib(30)
+    answer = 0
+
+    if n < 2: continue
+
+    a = 0
+    b = 1
+
+    for j in range(2, n+1):
+        c = a + b
+        a = b
+        b = c
+
+    answer = b
+
+print("Result in r0:")
+print(answer)

--- a/MS2Proto3/tools/examples/recur_fib.lua
+++ b/MS2Proto3/tools/examples/recur_fib.lua
@@ -1,0 +1,8 @@
+function rfib(n)
+    if n < 1 then return 0 end
+    if n == 1 then return 1 end
+    return rfib(n-1) + rfib(n-2)
+end
+
+print("Result in r0:")
+print(rfib(33))

--- a/MS2Proto3/tools/examples/recur_fib.py
+++ b/MS2Proto3/tools/examples/recur_fib.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Recursive Fibonacci sequence."""
+
+def rfib(n):
+    if n < 1:
+        return 0
+    if n == 1:
+        return 1
+    return rfib(n-1) + rfib(n-2)
+
+print("Result in r0:")
+print(rfib(33))


### PR DESCRIPTION
Changes:

1. Added Python and Lua to the benchmark tests
2. Changed formatting of the output.

New Requirements:

1. `python` and `lua` must be found on the command line somewhere.
2. All benchmark tests now need an equivalent python and lua test in `tools\examples` with the appropriate extension: ".py" for python, and ".lua" for lua.

TODO:

1. If there's an error in one of the benchmarks, it doesn't always capture the output correctly.
2. "unused" is displayed when there is an error with `factorial_iterative` instead of an actual expected value. This should be changed to reflect one or all of the potential answers.