### PR TITLE
ss_replaceChar implementation

### DIFF
--- a/MS2Proto3/cpp/core/StringPool.cpp
+++ b/MS2Proto3/cpp/core/StringPool.cpp
@@ -3,7 +3,9 @@
 #include "CS_String.h"
 #include "hashing.h"
 #include <cstring>  // strlen, memcpy
-#include <malloc/malloc.h> // for debugging (malloc_size) on macOS
+#if defined(__APPLE__)
+    #include <malloc/malloc.h> // for debugging (malloc_size) on macOS
+#endif
 #include <cstdio>
 
 uint8_t String::defaultPool = 0;

--- a/MS2Proto3/cpp/core/StringStorage.c
+++ b/MS2Proto3/cpp/core/StringStorage.c
@@ -526,9 +526,31 @@ StringStorage* ss_replace(const StringStorage* storage, const StringStorage* old
 }
 
 StringStorage* ss_replaceChar(const StringStorage* storage, char oldChar, char newChar, StringStorageAllocator allocator) {
-    // TODO: Implement
-    (void)storage; (void)oldChar; (void)newChar; (void)allocator;
-    return NULL;
+    if (!storage) return NULL;
+
+    // No sense in trying to replace '\0'. Return a copy of original.
+    if ((oldChar == '\0') || (newChar == '\0')) {
+        return ss_create(storage->data, allocator);
+    }
+
+    // Allocate new StringStorage
+    StringStorage* result = (StringStorage*)allocator(sizeof(StringStorage) + storage->lenB + 1);
+    if (!result) return NULL;
+
+    result->lenB = storage->lenB;
+    result->lenC = -1; // Will be computed on demand
+    result->hash = 0;  // Will be computed on demand
+
+    // Build the result string
+    char* dest = result->data;
+    const char* src = storage->data;
+
+    while (*src) { // We'll do it manually
+        *dest = *src == oldChar ? newChar : *src;
+    }
+
+    *dest = '\0';
+    return result;
 }
 
 StringStorage** ss_splitStr(const StringStorage* storage, const StringStorage* separator, int* count, StringStorageAllocator allocator) {

--- a/MS2Proto3/cpp/core/StringStorage.c
+++ b/MS2Proto3/cpp/core/StringStorage.c
@@ -525,11 +525,11 @@ StringStorage* ss_replace(const StringStorage* storage, const StringStorage* old
     return result;
 }
 
-StringStorage* ss_replaceChar(const StringStorage* storage, char oldChar, char newChar, StringStorageAllocator allocator) {
+StringStorage* ss_replaceByte(const StringStorage* storage, char oldChar, char newChar, StringStorageAllocator allocator) {
     if (!storage) return NULL;
 
     // No sense in trying to replace '\0'. Return a copy of original.
-    if ((oldChar == '\0') || (newChar == '\0')) {
+    if (oldChar == '\0') {
         return ss_create(storage->data, allocator);
     }
 

--- a/MS2Proto3/cpp/core/StringStorage.h
+++ b/MS2Proto3/cpp/core/StringStorage.h
@@ -69,7 +69,8 @@ StringStorage* ss_insert(const StringStorage* storage, int startIndex, const Str
 StringStorage* ss_remove(const StringStorage* storage, int startIndex, StringStorageAllocator allocator);
 StringStorage* ss_removeLen(const StringStorage* storage, int startIndex, int count, StringStorageAllocator allocator);
 StringStorage* ss_replace(const StringStorage* storage, const StringStorage* oldValue, const StringStorage* newValue, StringStorageAllocator allocator);
-StringStorage* ss_replaceChar(const StringStorage* storage, char oldChar, char newChar, StringStorageAllocator allocator);
+StringStorage* ss_replaceByte(const StringStorage* storage, char oldChar, char newChar, StringStorageAllocator allocator);
+StringStorage* ss_replaceChar(const StringStorage* storage, const char *oldChar, const char *newChar, StringStorageAllocator allocator);
 
 // Case conversion (ASCII only)
 StringStorage* ss_toLower(const StringStorage* storage, StringStorageAllocator allocator);


### PR DESCRIPTION
1. Added pre-processor header check if we're on macOS before attempting to include Mac-specific header. (It stops Linux from compiling otherwise.)
2. Implementation of `ss_replaceChar()`.

Note: This implementation won't work for a UTF-8 char that uses more than one byte, since the parameters of `ss_replaceChar()` that represent both the old character and new character are both `char` in size. This may need to be reconsidered.